### PR TITLE
publish to rubygems instead of gemfury

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Omniauth::Gds
 
-TODO: Write a gem description
+Omniauth strategy for GDS oauth2 provider
 
 ## Installation
 

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,6 @@ require "bundler/gem_tasks"
 require "gem_publisher"
 
 task :publish_gem do |t|
-  gem = GemPublisher.publish_if_updated "omniauth-gds.gemspec", :gemfury, as: "govuk"
+  gem = GemPublisher.publish_if_updated "omniauth-gds.gemspec", :rubygems
   puts "Published #{gem}" if gem
 end


### PR DESCRIPTION
This gem is a public github repo; so we might as well publish it to rubygems.

Further, the gds-sso gem is on rubygems and depends on this gem, and its ugly having it depend
on a private gem.
