### PR TITLE
Add organisations field

### DIFF
--- a/lib/omniauth/strategies/gds.rb
+++ b/lib/omniauth/strategies/gds.rb
@@ -14,7 +14,8 @@ class OmniAuth::Strategies::Gds < OmniAuth::Strategies::OAuth2
   extra do
     {
       user: user,
-      permissions: user['permissions']
+      permissions: user['permissions'],
+      organisations: user['organisations'],
     }
   end
 


### PR DESCRIPTION
Signon will soon expose organisations in the user.json, so it should be reflected in this gem. This will let gds-sso access the data, for example.
