### PR TITLE
Change organisations to organisation

### DIFF
--- a/lib/omniauth/strategies/gds.rb
+++ b/lib/omniauth/strategies/gds.rb
@@ -15,7 +15,7 @@ class OmniAuth::Strategies::Gds < OmniAuth::Strategies::OAuth2
     {
       user: user,
       permissions: user['permissions'],
-      organisations: user['organisations'],
+      organisation: user['organisation'],
     }
   end
 


### PR DESCRIPTION
This means simpler code in Signon and apps using organisation membership, and simplifies Signon conceptually.

Nothing is using "organisations" yet, so the breaking change shouldn't be a problem.

I did wonder about yanking the version with "organisations", but it's probably a bad idea.
