### PR TITLE
Add multi_json and remove gemfury from gemspec

### DIFF
--- a/omniauth-gds.gemspec
+++ b/omniauth-gds.gemspec
@@ -19,6 +19,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'multi_json', '~> 1.10'
 
   gem.add_development_dependency 'rake'
-  gem.add_development_dependency "gemfury"
   gem.add_development_dependency 'gem_publisher', '1.2.0'
 end


### PR DESCRIPTION
We depend on multi_json, so should declare this.

We're publishing this to rubygems now, so we no longer need the gemfury gem.
