### PR TITLE
Include client_id when requesting user details.

### DIFF
--- a/lib/omniauth/strategies/gds.rb
+++ b/lib/omniauth/strategies/gds.rb
@@ -20,7 +20,7 @@ class OmniAuth::Strategies::Gds < OmniAuth::Strategies::OAuth2
   end
 
   def user
-    @user ||= MultiJson.decode(access_token.get('/user.json').body)['user']
+    @user ||= MultiJson.decode(access_token.get("/user.json?client_id=#{CGI.escape(options.client_id)}").body)['user']
   end
 
 end


### PR DESCRIPTION
To fix a token transfer issue.  See
https://github.com/alphagov/signonotron2/pull/245 for more details.
