### PR TITLE
Add support for the organisation_content_id field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+## Unreleased
+
+* Feature: add support for organisation_content_id

--- a/lib/omniauth/strategies/gds.rb
+++ b/lib/omniauth/strategies/gds.rb
@@ -16,6 +16,7 @@ class OmniAuth::Strategies::Gds < OmniAuth::Strategies::OAuth2
       user: user,
       permissions: user['permissions'],
       organisation_slug: user['organisation_slug'],
+      organisation_content_id: user['organisation_content_id'],
     }
   end
 


### PR DESCRIPTION
We want to move away from organisation_slug as these change whereas content_ids
are stable. Successfully tested in development.

Depends on: https://github.com/alphagov/signonotron2/pull/344