### PR TITLE
Pin `omniauth-oauth2` at last stable version

### DIFF
--- a/omniauth-gds.gemspec
+++ b/omniauth-gds.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Omniauth::Gds::VERSION
 
-  gem.add_dependency 'omniauth-oauth2', '~> 1.0'
+  gem.add_dependency 'omniauth-oauth2', '1.3.1'
   gem.add_dependency 'multi_json', '~> 1.10'
 
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
The bump to `1.4.x` caused breaking changes that rippled out since this
dependency is pessimistically specified to `1.x`.

This is in lieu of investigations into what exactly caused the
downstream breakages.