### PR TITLE
Release 3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.2.1
+
+* Bugfix: pin `omniauth-oauth2` to last known stable version
+
 ## 3.2.0
 
 * Feature: add support for organisation_content_id

--- a/lib/omniauth-gds/version.rb
+++ b/lib/omniauth-gds/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Gds
-    VERSION = "3.2.0"
+    VERSION = "3.2.1"
   end
 end


### PR DESCRIPTION
Bump a patch version to pin the `omniauth-oauth2` dependency to the last
known stable release.

@boffbowsh @jamiecobbett