### PR TITLE
Document project archiving

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Omniauth::Gds
 
+**This project was archived in October 2022, the functionality has been ported into [gds-sso](https://github.com/alphagov/gds-sso/pull/262).**
+
 Omniauth strategy for GDS oauth2 provider
 
 ## Installation


### PR DESCRIPTION
Trello: https://trello.com/c/QrxjshEm/270-move-ruby-gems-from-jenkins-to-github-actions

This is a draft until https://github.com/alphagov/gds-sso/pull/262 is merged and released.

We are archiving this gem because the functionality has now been ported to the GDS-SSO gem. This is a change to the readme that will remain in posterity once the repository is archived.